### PR TITLE
Quitando cambios email y contraseña reservas

### DIFF
--- a/app/Http/Controllers/Web/AppointmentController.php
+++ b/app/Http/Controllers/Web/AppointmentController.php
@@ -42,13 +42,13 @@ class AppointmentController extends AppBaseController
                 $this->appointmentRepository->create($input);
             }
 
-            if ($input['patient_type'] == 1 && ! empty($input['patient_type'])) {
+            /*if ($input['patient_type'] == 1 && ! empty($input['patient_type'])) {
                 $emailExists = User::whereEmail($input['email'])->exists();
                 if ($emailExists) {
                     return $this->sendError('Email already exists, please select old patient.');
                 }
                 $this->appointmentRepository->createNewAppointment($input);
-            }
+            }*/
 
             DB::commit();
 

--- a/app/Http/Requests/CreateWebAppointmentRequest.php
+++ b/app/Http/Requests/CreateWebAppointmentRequest.php
@@ -28,11 +28,11 @@ class CreateWebAppointmentRequest extends FormRequest
             'department_id' => 'required',
             'opd_date'      => 'required',
             'problem'       => 'nullable',
-            'email'         => 'required|email:filter',
+            //'email'         => 'nullable|email:filter',
         ];
-        if (request()->get('patient_type') == 1) {
+        /*if (request()->get('patient_type') == 1) {
             $validationFields['password'] = 'required|same:password_confirmation|min:6';
-        }
+        }*/
         if (request()->get('patient_type') == 2) {
             $validationFields['patient_id'] = 'required';
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -215,7 +215,7 @@ class User extends Authenticatable implements HasMedia, MustVerifyEmail
     public static $rules = [
         'first_name'    => 'required',
         'last_name'     => 'required',
-        'email'         => 'required|email:filter|unique:users,email',
+        'email'         => 'nullable|email:filter|unique:users,email',
         'password'      => 'nullable|same:password_confirmation|min:6',
         'department_id' => 'required',
         'gender'        => 'required',

--- a/app/Repositories/AppointmentRepository.php
+++ b/app/Repositories/AppointmentRepository.php
@@ -264,9 +264,13 @@ class AppointmentRepository extends BaseRepository
             $input['department_id'] = Department::whereName('Patient')->first()->id;
             $input['dob'] = (! empty($input['dob']) || isset($input['dob'])) ? $input['dob'] : null;
             $input['phone'] = (! empty($input['phone']) || isset($input['phone'])) ? $input['phone'] : null;
-            $input['password'] = Hash::make($input['password']);
+            //$input['password'] = Hash::make($input['password']);
+
+
             $userData = Arr::only($input,
-                ['first_name', 'last_name', 'gender', 'password', 'email', 'department_id', 'status']);
+                //['first_name', 'last_name', 'gender', 'password', 'email', 'department_id', 'status']);
+                ['first_name', 'last_name', 'gender', 'department_id', 'status']);
+
 
             $user = User::create($userData);
             if (isset($input['email'])) {
@@ -280,14 +284,16 @@ class AppointmentRepository extends BaseRepository
             $user->update(['owner_id' => $ownerId, 'owner_type' => $ownerType]);
             $user->assignRole($input['department_id']);
 
+
+            $date = explode('[object HTMLInputElement]',$input['opd_date'])[0];
+
             $appointment = Appointment::create([
                 'patient_id'    => $patient->id,
-                'doctor_id'     => $input['doctor_id'],
-                'department_id' => $appointmentDepartmentId,
-                'opd_date'      => $input['opd_date'],
+                'doctor_id'     => (int)$input['doctor_id'],
+                'department_id' => (int)$appointmentDepartmentId,
+                'opd_date'      => $date,
                 'problem'       => $input['problem'],
             ]);
-
 
             DB::commit();
 

--- a/resources/views/web/home/appointment_fields.blade.php
+++ b/resources/views/web/home/appointment_fields.blade.php
@@ -11,12 +11,6 @@
             <label class="mb-0 label-mt-3">{{ __('messages.old_patient') }}</label>
         </div>
     </div>
-    <div class="form-group col-md-6 patient-email-div mb-4">
-        <label>{{__('messages.user.email')}}:
-            <span class="text text-danger">*</span>
-        </label>
-        {{ Form::email('email', null, ['class' => 'form-control form-control-solid old-patient-email','placeholder'=>Lang::get('messages.web_contact.enter_your_email'),'autocomplete' => 'off','required']) }}
-    </div>
 
     <div class="form-group col-sm-6 old-patient d-none mb-4">
         <label for="patient_id">{{__('messages.appointment.patient_name')}}:
@@ -49,19 +43,6 @@
             {{ Form::radio('gender', '1', false, ['class' => 'form-check-input radio_btn', 'id' => 'flexRadioSm']) }}
             <label class="mb-0 label-mt-3">{{ __('messages.user.female') }}</label>
         </div>
-    </div>
-
-    <div class="form-group col-xl-3 col-md-6 password-div mb-4">
-        <label for="password">{{__('messages.user.password')}}:
-            <span class="text text-danger">*</span>
-        </label>
-        {{ Form::password('password', ['class' => 'form-control form-control-solid','placeholder'=>Lang::get('messages.web_appointment.enter_your_password'),'required','min' => '6','max' => '10','id'=>'password']) }}
-    </div>
-    <div class="form-group col-xl-3 col-md-6 confirm-password-div mb-4">
-        <label for="password_confirmation">{{__('messages.user.password_confirmation')}}:
-            <span class="text text-danger">*</span>
-        </label>
-        {{ Form::password('password_confirmation', ['class' => 'form-control form-control-solid','placeholder'=>Lang::get('messages.web_appointment.enter_confirm_password'),'required','min' => '6','max' => '10','id'=>'confirmPassword']) }}
     </div>
 
     <div class="form-group drop_down col-sm-6 mb-4">


### PR DESCRIPTION
Hay que cambiar el campo de email required en la base de datos en la tabla users para que se pueda registrar sin ese campo, y hay que deshabilitar todos los campos en los cuales solicita email y password para poder reservar